### PR TITLE
unzip not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd -m ghidra && \
 COPY --chown=ghidra:ghidra launch.sh.patch /tmp/
 
 WORKDIR /opt
-RUN apt-get update && apt-get install -y wget gettext-base patch && \
+RUN apt-get update && apt-get install -y unzip wget gettext-base patch && \
     wget -q -O ghidra.zip https://ghidra-sre.org/ghidra_${GHIDRA_VERSION}.zip && \
     echo "${GHIDRA_SHA256} *ghidra.zip" | sha256sum -c && \
     unzip ghidra.zip && \


### PR DESCRIPTION
tried to build today and looks like unzip is not installed by default in the base image anymore.
```
processing triggers for libc-bin (2.24-11+deb9u4) ...
ghidra.zip: OK
/bin/sh: 1: unzip: not found
The command '/bin/sh -c apt-get update && apt-get install -y wget gettext-base patch &&     wget -q -O ghidra.zip https://ghidra-sre.org/ghidra_${GHIDRA_VERSION}.zip &&     echo "${GHIDRA_SHA256} *ghidra.zip" | sha256sum -c &&     unzip ghidra.zip &&     rm ghidra.zip &&     ln -s ghidra* ghidra &&     cd ghidra &&     patch -p0 < /tmp/launch.sh.patch &&     rm -rf docs &&     cd .. &&     chown -R ghidra: ghidra*' returned a non-zero code: 127
```